### PR TITLE
update dependency due to security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "bluebird": "~3.2.2",
-    "request": "~2.69.0"
+    "request": "~2.74.0"
   },
   "devDependencies": {
     "typescript": "~1.9.0-dev.20160205",


### PR DESCRIPTION
Given: https://nodesecurity.io/advisories/130
which points out a problem in `tough-cookie` which is sub-dependency of your dependency on `request` ... Would you mind updating `request` version which uses a more up-to-date version of `tough-cookie`?
