### PR TITLE
Upgrade request dependency to fix 4 vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ package-lock.json
 *.log.*
 *.log
 *.tgz
+
+test/cache2

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
     "http"
   ],
   "dependencies": {
-    "@types/bluebird": "^3.5.10",
-    "@types/node": "^8.0.28",
-    "@types/request": "2.0.3",
-    "bluebird": "^3.5.0",
+    "bluebird": "^3.5.1",
     "cwait": "^1.1.1",
-    "request": "~2.81.0"
+    "request": "^2.87.0"
   },
   "devDependencies": {
+    "@types/bluebird": "^3.5.20",
+    "@types/node": "^8.0.28",
+    "@types/request": "^2.47.0",
     "typescript": "^2.5.2"
   }
 }

--- a/test/ds9k.ts
+++ b/test/ds9k.ts
@@ -30,7 +30,7 @@ export const enum ProblemBase {
   * Note that closing the connection in the middle of data,
   * without timeout or content length, cannot be distinguished from success. */
 
-export const enum Problem {
+export enum Problem {
 	none = 0,
 
 	closeMask = ProblemBase.close * 3,
@@ -86,7 +86,7 @@ class Error9k extends Error {
 export function requestHandler(req: http.IncomingMessage, res: http.ServerResponse) {
 	const parts = url.parse(req.url!);
 	const match = (parts.query || '').match(/problem=([0-9]+)/);
-	const problem = match ? match[1] as Problem : Problem.none;
+	const problem: Problem = (<any>Problem)[match ? match[1] : "none"];
 	const problemClose = problem & Problem.closeMask;
 	const problemStatus = problem & Problem.statusMask;
 


### PR DESCRIPTION
Based on the npm audit security report, upgrading request to 2.87.0 is recommended to resolve the following vulnerabilities related to https://nodesecurity.io/advisories/566.